### PR TITLE
add egress, secret vars

### DIFF
--- a/greymatter/main.tf
+++ b/greymatter/main.tf
@@ -1,3 +1,6 @@
+provider "aws" {
+  region = "us-east-2"
+}
 
 module "infrastructure" {
   source                       = "./modules/infrastructure"
@@ -19,4 +22,6 @@ module "fabric" {
   cluster_id             = module.infrastructure.gm_cluster_id
   subnets                = var.subnets
   gm_sg_id               = module.infrastructure.gm_sg_id
+  access_key_arn         = var.access_key_arn
+  secret_access_key_arn  = var.secret_access_key_arn
 }

--- a/greymatter/modules/fabric/security_groups.tf
+++ b/greymatter/modules/fabric/security_groups.tf
@@ -9,6 +9,13 @@ resource "aws_security_group" "control-api-sg" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 resource "aws_security_group_rule" "control-api-ingress" {
@@ -29,6 +36,13 @@ resource "aws_security_group" "control-sg" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 resource "aws_security_group_rule" "control-ingress" {
@@ -47,6 +61,13 @@ resource "aws_security_group" "control-api-sidecar-sg" {
     from_port   = 10808
     to_port     = 10808
     protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/greymatter/modules/fabric/services.tf
+++ b/greymatter/modules/fabric/services.tf
@@ -9,6 +9,7 @@ resource "aws_ecs_service" "control-api" {
     iam_role = var.service_role_arn
     desired_count = 1
     depends_on      = [aws_lb_target_group.control-api]
+    health_check_grace_period_seconds = 180000000
 
     load_balancer {
         target_group_arn = aws_lb_target_group.control-api.arn
@@ -24,6 +25,7 @@ resource "aws_ecs_service" "control" {
     iam_role = var.service_role_arn
     desired_count = 1
     depends_on      = [aws_lb_target_group.control]
+    health_check_grace_period_seconds = 180000000
 
     load_balancer {
         target_group_arn = aws_lb_target_group.control.arn
@@ -39,6 +41,7 @@ resource "aws_ecs_service" "control-api-sidecar" {
     iam_role = var.service_role_arn
     desired_count = 1
     depends_on      = [aws_lb_target_group.control-api]
+    health_check_grace_period_seconds = 180000000
 
     load_balancer {
         target_group_arn = aws_lb_target_group.control-api-sidecar.arn

--- a/greymatter/modules/fabric/tasks.tf
+++ b/greymatter/modules/fabric/tasks.tf
@@ -113,6 +113,16 @@ locals {
             "awslogs-stream-prefix": "control"
         }
     },
+    "secrets": [
+        {
+            "name": "GM_CONTROL_ECS_AWS_ACCESS_KEY_ID",
+            "valueFrom": "${var.access_key_arn}"
+        },
+        {
+            "name": "GM_CONTROL_ECS_AWS_SECRET_ACCESS_KEY",
+            "valueFrom": "${var.secret_access_key_arn}"
+        }
+    ],
 	"environment": [
         {
             "name": "GM_CONTROL_CONSOLE_LEVEL",

--- a/greymatter/modules/fabric/variables.tf
+++ b/greymatter/modules/fabric/variables.tf
@@ -23,3 +23,7 @@ variable "subnets" {
 }
 
 variable "gm_sg_id" {}
+
+variable "access_key_arn" {}
+
+variable "secret_access_key_arn" {}

--- a/greymatter/variables.tf
+++ b/greymatter/variables.tf
@@ -37,3 +37,7 @@ variable "autoscaling_service_role_arn" {
 
 variable "subnets" {
 }
+
+variable "access_key_arn" {}
+
+variable "secret_access_key_arn" {}


### PR DESCRIPTION
this adds an egress block to security group gm-sg which fixed the problem of no container instances being registered for the ecs cluster for me (yay!)

it also adds back the secret arn variables for `"GM_CONTROL_ECS_AWS_ACCESS_KEY_ID"` and `"GM_CONTROL_ECS_AWS_SECRET_ACCESS_KEY"`. i know you said they should automatically populate but i haven't been able to get the setup to work without them?

lastly i added a provider block to the greymatter module (just for now) until we have as PR ready to bring up the vpc, igw, etc in main.tf because i was able to run greymatter standalone by just adding that provider and passing env vars straight in with `terraform apply -var-file=file` from the greymatter directory

this also includes what worked for me as a fix for #9 