### PR TITLE
Cleanup

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sofiashalotenko @zoemccormick
+* @sofiashalotenko @zoemccormick @dontlaugh

--- a/README.md
+++ b/README.md
@@ -2,55 +2,6 @@
 
 Grey Matter Terraform Code to Deploy Grey Matter using AWS ECS
 
-## Pre-install
+For instructions on installation, see [install](./docs/install.md).
 
-1. Create 2 parameters in AWS systems manager paremeter store. One named `access_key` with type Secured String and the value the aws access key for your profile. Name the second `secret_access_key` and Secured String value of the corresponding secret access key id. Copy the arns and pass them to terraform as variables `access_key_arn` and `secret_access_key_arn`.
-
-2. Run `aws kms describe-key --key-id alias/aws/ssm`, copy the Arn and set it as variable `kms_ssm_arn`.
-
-3. Run `aws kms describe-key --key-id alias/aws/secretsmanager`, copy the Arn and set it as variable `kms_secretsmanager_arn`.
-
-4. Get the ecs optimized ami for your region [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html), and set its id as variable `optimized_ami`.
-
-5. If you're running the `greymatter` module on its own, you will need to create a directory `gm` wherever you are running `terraform apply` from,  subdirectories `certs` and `mesh`. Copy [this file](./gm) for defaults. If you want to use certs that are not the quickstart, replace them in the corresponding service directories.
-
-Look through the remaining [variables](greymatter/variables.tf) and make sure to enter the correct values.
-
-## Install
-
-Create a var file that looks like the following:
-
-```bash
-access_key_arn         = "{output of step 1 in pre-install}"
-secret_access_key_arn  = "{output of step 1 in pre-install}"
-aws_region             = "{region}"
-key_pair_name          = "{name of existing keypair for ssh}"
-kms_ssm_arn            = "{output of step 3 in pre-install}"
-kms_secretsmanager_arn = "{output of step 4 in pre-install}"
-optimized_ami          = "{ecs optimized ami - found [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-ami-linux) }"
-docker_gm_credentials  = {"username": "{greymatter-nexus-email}", "password": "{greymatter-nexus-password}"}
-```
-
-To install the mesh:
-
-```bash
-terraform apply -var-file=varfile.tfvars
-```
-
-When applied, the edge dns name should be output. Give the target group a few minutes to register the edge service target before moving on to the next step.
-
-### Mesh configs
-
-You should be able to reach control-api through the edge dns name on startup. Once the edge target group registered target is healthy, navigate to `http://{edge-dns}:10808/services/control-api/latest/` to verify this.
-
-Once you can reach control-api, configure the cli, filling in {edge_dns}:
-
-```bash
-export GREYMATTER_API_HOST={edgs_dns}:10808
-export GREYMATTER_API_INSECURE=true
-export GREYMATTER_API_PREFIX=/services/control-api/latest
-export GREYMATTER_API_SSL=false
-export GREYMATTER_CONSOLE_LEVEL=debug
-```
-
-and run `./gm/mesh/apply.sh`.  This will apply the proper mesh configs for edge -> control-api-sidecar -> control-api through with ssl. It will also delete the old routes directly from edge to control-api-service. The CLI should still be properly configured.
+For development info, see [code](./docs/code.md).

--- a/docs/code.md
+++ b/docs/code.md
@@ -1,0 +1,3 @@
+# Terraform
+
+If you're working on this tf code:

--- a/docs/code.md
+++ b/docs/code.md
@@ -16,13 +16,13 @@ The infrastructure module brings up the ECS cluster itself, as well as any neces
 
 ### Fabric
 
-The fabric module creates ECS services for control and control-api. Control is run with REST enabled, and a private route53 domain is created at `fabric.${var.dns_ns_name}` where other services within the VPC can connect to both control and control-api at `control.fabric.${var.dns_ns_name}:50001` and `control-api.fabric.${var.dns_ns_name}:5555` respectively.
+The fabric module creates ECS services for gm-control and gm-control-api. Grey Matter Control is run with REST enabled, and a private route53 domain is created at `fabric.${var.dns_ns_name}` where other services within the VPC can connect to both gm-control and gm-control-api at `control.fabric.${var.dns_ns_name}:50001` and `control-api.fabric.${var.dns_ns_name}:5555` respectively.
 
-Control-api is bootstrapped with mesh configs found in [this file](../greymatter/modules/fabric/mesh/backup.json) - which creates a route from edge -> control-api at startup. Once the mesh comes up, this route should be replaced by mesh configs routeing from edge -> control-api-sidecar -> control-api.
+Grey Matter Control Api is bootstrapped with mesh configs found in [this file](../greymatter/modules/fabric/mesh/backup.json) - which creates a route from edge -> gm-control-api at startup. Once the mesh comes up, this route should be replaced by mesh configs routeing from edge -> gm-control-api-sidecar -> gm-control-api.
 
 ### Edge
 
-The edge module creates an ECS service for edge as well as a load balancer for ingress.
+The edge module creates an ECS service for the edge proxy as well as a load balancer for ingress. The edge is a standalone sidecar and will serve as the ingress proxy for all traffic from the outside world into the mesh.
 
 ### Sidecar
 

--- a/docs/code.md
+++ b/docs/code.md
@@ -1,3 +1,29 @@
 # Terraform
 
-If you're working on this tf code:
+If you're working on this tf code, the basic structure is described here.
+
+## Main
+
+Anything created in the `main.tf` of the root directory is a VPC setup with public and private subnets.
+
+## Greymatter module
+
+The [`greymatter` module](./../greymatter/main.tf) runs all of the internal modules to install Grey Matter:
+
+### Infrastructure
+
+The infrastructure module brings up the ECS cluster itself, as well as any necessary AWS roles to be re-used by ECS tasks, services, etc. and aws and docker secret credentials.
+
+### Fabric
+
+The fabric module creates ECS services for control and control-api. Control is run with REST enabled, and a private route53 domain is created at `fabric.${var.dns_ns_name}` where other services within the VPC can connect to both control and control-api at `control.fabric.${var.dns_ns_name}:50001` and `control-api.fabric.${var.dns_ns_name}:5555` respectively.
+
+Control-api is bootstrapped with mesh configs found in [this file](../greymatter/modules/fabric/mesh/backup.json) - which creates a route from edge -> control-api at startup. Once the mesh comes up, this route should be replaced by mesh configs routeing from edge -> control-api-sidecar -> control-api.
+
+### Edge
+
+The edge module creates an ECS service for edge as well as a load balancer for ingress.
+
+### Sidecar
+
+The sidecar module is a reusable module that creates a sidecar for the service specified with variable `name`. Its ECS task definition specifies `dockerLabels`, with key `gm-cluster` and value `${var.name}:${var.sidecar_port}` so that it's instances will be discovered by gm-control.

--- a/docs/install.md
+++ b/docs/install.md
@@ -66,15 +66,15 @@ To install the `greymatter` module into an existing VPC, add the following to yo
 ```tf
 module "greymatter" {
   source                 = "git::ssh://git@github.com/greymatter-io/terraform-greymatter-ecs//greymatter?ref=master"
-  key_pair_name          = var.key_pair_name
+  key_pair_name          = "<existing key pair name for ssh>"
   vpc_id                 = "<id of existing vpc to install in>"
   public_subnets         = <list of existing public subnets of vpc>
   private_subnets        = <list of existing private subnets of vpc>
-  aws_region             = var.aws_region
-  optimized_ami          = var.optimized_ami
-  docker_gm_credentials  = var.docker_gm_credentials
-  aws_access_key_id      = var.aws_access_key_id
-  aws_secret_access_key  = var.aws_secret_access_key
+  aws_region             = "<aws region to install>"
+  optimized_ami          = "<ecs optimized ami id for your region - found [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-ami-linux)>"
+  docker_gm_credentials  = { "username" : "<greymatter nexus email>", "password" : "<greymatter nexus password>" }
+  aws_access_key_id      = "<aws_access_key_id>"
+  aws_secret_access_key  = "<aws_secret_access_key>"
 }
 
 output "gm_edge_dns" {
@@ -82,16 +82,15 @@ output "gm_edge_dns" {
 }
 ```
 
-> Note: if you specified any of the optional variables, include them in the module in the form `<var_name> = var.<var_name>`.
+> Note: if you want to specify any [optional variables](#optional-environment-variables), include them in the module in the form `<var_name> = <value>`.
 
-Before installing, you **must** copy the [`gm`](gm) directory into the location you are running `terraform apply` from. You can replace the certificates with your own as per [these instructions](#certificates).
+**Before installing, you must** copy the [`gm`](gm) directory into the location you are running `terraform apply` from. You can replace the certificates with your own as per [these instructions](#certificates).
 
 For the following command, the directory structure should look like:
 
 ```bash
 /
 ├── your-terraform.tf
-├── gm.tfvars
 ├── gm
 │   ├── certs
 │       ├── control
@@ -118,7 +117,7 @@ For the following command, the directory structure should look like:
 To install, run:
 
 ```bash
-terraform apply -var-file=gm.tfvars
+terraform apply
 ```
 
 then, [configure the mesh](#configure-the-mesh).

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ ec2_max_instances      = <max & desired number of ec2 instances for the ecs clus
 ec2_min_instances      = <min number of ec2 instances for the ecs cluster>
 ```
 
-Note that when specifying ec2 instances and instance type, the ecs tasks will fail if allowed resources are not enough, see [the aws documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html#eni-trunking-supported-instance-types) on resources for instance types.
+Note that when specifying ec2 instances and instance type, the ecs tasks will fail if allowed resources are insufficient. See [the aws documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html#eni-trunking-supported-instance-types) on resources for instance types.
 
 If not specified, they have the following defaults:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,136 @@
+# Install
+
+Instructions on installing Grey Matter on ECS.
+
+There are several options for installing. This repo contains a full installation including the creation of a VPC and subnets. The `greymatter` module can also be installed into an existing VPC.
+
+## Environment
+
+Create a file `gm.tfvars` that looks like the following:
+
+```bash
+aws_region             = "<aws region to install>"
+key_pair_name          = "<existing key pair name for ssh>"
+optimized_ami          = "<ecs optimized ami id for your region - found [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-ami-linux)>"
+docker_gm_credentials  = { "username" : "<greymatter docker email>", "password" : "<greymatter docker password>" }
+aws_access_key_id      = "<aws access key id>"
+aws_secret_access_key  = "<aws secret access key>"
+```
+
+and fill in the values inside of `<>`.
+
+> Note: Optionally, you can also set:
+
+  ```bash
+  cluster_name           = "<name of Grey Matter ECS cluster to be created>"
+  dns_ns_name            = "<desired domain name for Grey Matter Route 53 Hosted Zones>"
+  ec2_instance_type      = "<ec2 instance type for ecs cluster>"
+  ec2_max_instances      = <max & desired number of ec2 instances for the ecs cluster>
+  ec2_min_instances      = <min number of ec2 instances for the ecs cluster>
+  ```
+
+  Note that when specifying ec2 instances and instance type, the ecs tasks will fail if allowed resources are not enough, see [the aws documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html#eni-trunking-supported-instance-types) on resources for instance types.
+
+  If not specified, they have the following defaults:
+
+  ```bash
+  cluster_name           = "gm-cluster"
+  dns_ns_name            = "greymatter.dev"
+  ec2_instance_type      = "t3.xlarge"
+  ec2_max_instances      = 3
+  ec2_min_instances      = 0
+  ```
+
+### Certificates
+
+SSL will be turned on on the Grey Matter services and sidecars on install, using the certificates specified in the [`gm/certs`](gm/certs) directory. The default certs checked in here are the quickstart certificates. To customize these, replace the content of the `ca.crt`, `cert.crt` and `key.crt` files for the services. Note that they must stay in the same directories and must still be named `ca.crt`, `cert.crt` and `key.crt`.
+
+If you are installing the `greymatter` module into an existing VPC, follow the instructions [below](#grey-matter-module) to set this up.
+
+### Full Installation
+
+Save your `gm.tfvars` file in the root directory of this repo and run:
+
+```bash
+terraform apply -var-file=gm.tfvars
+```
+
+### Grey Matter Module
+
+To install the `greymatter` module into an existing VPC, add the following to your tf code:
+
+```tf
+module "greymatter" {
+  source                 = "git::ssh://git@github.com/greymatter-io/terraform-greymatter-ecs//greymatter?ref=master"
+  key_pair_name          = var.key_pair_name
+  vpc_id                 = "<id of existing vpc to install in>"
+  public_subnets         = <list of existing public subnets of vpc>
+  private_subnets        = <list of existing private subnets of vpc>
+  aws_region             = var.aws_region
+  optimized_ami          = var.optimized_ami
+  docker_gm_credentials  = var.docker_gm_credentials
+  aws_access_key_id      = var.aws_access_key_id
+  aws_secret_access_key  = var.aws_secret_access_key
+}
+
+output "gm_edge_dns" {
+  value = module.greymatter.edge_dns
+}
+```
+
+> Note: if you specified any of the optional variables, include them in the module in the form `<var_name> = var.<var_name>`.
+
+Before installing, you **must** copy the [`gm`](gm) directory into the location you are running `terraform apply` from. You can replace the certificates with your own as per [these instructions](#certificates).
+
+For the following command, the directory structure should look like:
+
+```bash
+/
+├── your-terraform.tf
+├── gm.tfvars
+├── gm
+│   ├── certs
+│       ├── control
+│           ├── ca.crt
+│           ├── cert.crt
+│           ├── key.crt
+│       ├── control-api
+│           ├── ca.crt
+│           ├── ...
+│       ├── sidecar
+│           ├── ca.crt
+│           ├── ...
+│       ...
+│   ├── mesh
+│       ├── apply.sh
+│       ├── control-api
+│           ├── cluster
+│           ├── domain
+│           ├── listener
+│           ├── proxy
+│           ├── route
+```
+
+To install, run:
+
+```bash
+terraform apply -var-file=gm.tfvars
+```
+
+### Configure the Mesh
+
+Once you have applied the terraform code, you should see the edge dns name output.
+
+You should be able to reach control-api through the edge dns name on startup. Once the edge target group registered target is healthy, navigate to `http://{edge-dns}:10808/services/control-api/latest/` to verify this.
+
+Once you can reach control-api, configure the cli, filling in {edge_dns}:
+
+```bash
+export GREYMATTER_API_HOST={edgs_dns}:10808
+export GREYMATTER_API_INSECURE=true
+export GREYMATTER_API_PREFIX=/services/control-api/latest
+export GREYMATTER_API_SSL=false
+export GREYMATTER_CONSOLE_LEVEL=debug
+```
+
+and run `./gm/mesh/apply.sh`.  This will apply the proper mesh configs for edge -> control-api-sidecar -> control-api through with ssl. It will also delete the old routes directly from edge to control-api-service. The CLI should still be properly configured.

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ There are several options for installing. This repo contains a full installation
 
 Create a file `gm.tfvars` that looks like the following:
 
-```bash
+```hcl
 aws_region             = "<aws region to install>"
 key_pair_name          = "<existing key pair name for ssh>"
 optimized_ami          = "<ecs optimized ami id for your region - found [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-ami-linux)>"
@@ -23,7 +23,7 @@ and fill in the values inside of `<>`.
 
 Optionally, you can also set:
 
-```bash
+```hcl
 cluster_name           = "<name of Grey Matter ECS cluster to be created>"
 dns_ns_name            = "<desired domain name for Grey Matter Route 53 Hosted Zones>"
 ec2_instance_type      = "<ec2 instance type for ecs cluster>"
@@ -35,7 +35,7 @@ Note that when specifying ec2 instances and instance type, the ecs tasks will fa
 
 If not specified, they have the following defaults:
 
-```bash
+```hcl
 cluster_name           = "gm-cluster"
 dns_ns_name            = "greymatter.dev"
 ec2_instance_type      = "t3.xlarge"

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,6 +57,8 @@ Save your `gm.tfvars` file in the root directory of this repo and run:
 terraform apply -var-file=gm.tfvars
 ```
 
+Next, [configure the mesh](#configure-the-mesh).
+
 ## Grey Matter Module
 
 To install the `greymatter` module into an existing VPC, add the following to your tf code:
@@ -118,6 +120,8 @@ To install, run:
 ```bash
 terraform apply -var-file=gm.tfvars
 ```
+
+then, [configure the mesh](#configure-the-mesh).
 
 ### Configure the Mesh
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -47,7 +47,7 @@ ec2_min_instances      = 0
 
 TLS will be turned on for the Grey Matter services and sidecars upon install. We use the certificates specified in the [`gm/certs`](gm/certs) directory. The default certs checked in here are self-signed certificates not suitable for production. To customize these, replace the content of the `ca.crt`, `cert.crt` and `key.crt` files for the services. Note that they must stay in the same directories and must still be named `ca.crt`, `cert.crt` and `key.crt`.
 
-If you are installing the `greymatter` module into an existing VPC, follow the instructions [below](#grey-matter-module) to set this up.
+If you are installing the `greymatter` module into an existing VPC, follow the instructions [below](#grey-matter-module).
 
 ## Full Installation
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -19,35 +19,37 @@ aws_secret_access_key  = "<aws secret access key>"
 
 and fill in the values inside of `<>`.
 
-> Note: Optionally, you can also set:
+### Optional environment variables
 
-  ```bash
-  cluster_name           = "<name of Grey Matter ECS cluster to be created>"
-  dns_ns_name            = "<desired domain name for Grey Matter Route 53 Hosted Zones>"
-  ec2_instance_type      = "<ec2 instance type for ecs cluster>"
-  ec2_max_instances      = <max & desired number of ec2 instances for the ecs cluster>
-  ec2_min_instances      = <min number of ec2 instances for the ecs cluster>
-  ```
+Optionally, you can also set:
 
-  Note that when specifying ec2 instances and instance type, the ecs tasks will fail if allowed resources are not enough, see [the aws documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html#eni-trunking-supported-instance-types) on resources for instance types.
+```bash
+cluster_name           = "<name of Grey Matter ECS cluster to be created>"
+dns_ns_name            = "<desired domain name for Grey Matter Route 53 Hosted Zones>"
+ec2_instance_type      = "<ec2 instance type for ecs cluster>"
+ec2_max_instances      = <max & desired number of ec2 instances for the ecs cluster>
+ec2_min_instances      = <min number of ec2 instances for the ecs cluster>
+```
 
-  If not specified, they have the following defaults:
+Note that when specifying ec2 instances and instance type, the ecs tasks will fail if allowed resources are not enough, see [the aws documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html#eni-trunking-supported-instance-types) on resources for instance types.
 
-  ```bash
-  cluster_name           = "gm-cluster"
-  dns_ns_name            = "greymatter.dev"
-  ec2_instance_type      = "t3.xlarge"
-  ec2_max_instances      = 3
-  ec2_min_instances      = 0
-  ```
+If not specified, they have the following defaults:
 
-### Certificates
+```bash
+cluster_name           = "gm-cluster"
+dns_ns_name            = "greymatter.dev"
+ec2_instance_type      = "t3.xlarge"
+ec2_max_instances      = 3
+ec2_min_instances      = 0
+```
+
+## Certificates
 
 SSL will be turned on on the Grey Matter services and sidecars on install, using the certificates specified in the [`gm/certs`](gm/certs) directory. The default certs checked in here are the quickstart certificates. To customize these, replace the content of the `ca.crt`, `cert.crt` and `key.crt` files for the services. Note that they must stay in the same directories and must still be named `ca.crt`, `cert.crt` and `key.crt`.
 
 If you are installing the `greymatter` module into an existing VPC, follow the instructions [below](#grey-matter-module) to set this up.
 
-### Full Installation
+## Full Installation
 
 Save your `gm.tfvars` file in the root directory of this repo and run:
 
@@ -55,7 +57,7 @@ Save your `gm.tfvars` file in the root directory of this repo and run:
 terraform apply -var-file=gm.tfvars
 ```
 
-### Grey Matter Module
+## Grey Matter Module
 
 To install the `greymatter` module into an existing VPC, add the following to your tf code:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -45,7 +45,7 @@ ec2_min_instances      = 0
 
 ## Certificates
 
-SSL will be turned on on the Grey Matter services and sidecars on install, using the certificates specified in the [`gm/certs`](gm/certs) directory. The default certs checked in here are the quickstart certificates. To customize these, replace the content of the `ca.crt`, `cert.crt` and `key.crt` files for the services. Note that they must stay in the same directories and must still be named `ca.crt`, `cert.crt` and `key.crt`.
+TLS will be turned on for the Grey Matter services and sidecars upon install. We use the certificates specified in the [`gm/certs`](gm/certs) directory. The default certs checked in here are self-signed certificates not suitable for production. To customize these, replace the content of the `ca.crt`, `cert.crt` and `key.crt` files for the services. Note that they must stay in the same directories and must still be named `ca.crt`, `cert.crt` and `key.crt`.
 
 If you are installing the `greymatter` module into an existing VPC, follow the instructions [below](#grey-matter-module) to set this up.
 

--- a/greymatter/main.tf
+++ b/greymatter/main.tf
@@ -4,12 +4,13 @@ module "infrastructure" {
   key_pair_name          = var.key_pair_name
   subnets                = concat(var.public_subnets, var.private_subnets)
   vpc_id                 = var.vpc_id
-  kms_ssm_arn            = var.kms_ssm_arn
-  kms_secretsmanager_arn = var.kms_secretsmanager_arn
-  access_key_arn         = var.access_key_arn
-  secret_access_key_arn  = var.secret_access_key_arn
   optimized_ami          = var.optimized_ami
   docker_gm_credentials  = var.docker_gm_credentials
+  aws_access_key_id      = var.aws_access_key_id
+  aws_secret_access_key  = var.aws_secret_access_key
+  instance_type          = var.ec2_instance_type
+  max_instances          = var.ec2_max_instances
+  min_instances          = var.ec2_min_instances
 }
 
 
@@ -23,8 +24,8 @@ module "fabric" {
   cluster_id            = module.infrastructure.gm_cluster_id
   subnets               = var.private_subnets
   gm_sg_id              = module.infrastructure.gm_sg_id
-  access_key_arn        = var.access_key_arn
-  secret_access_key_arn = var.secret_access_key_arn
+  access_key_arn        = module.infrastructure.ssm_access_key_arn
+  secret_access_key_arn = module.infrastructure.ssm_secret_access_key_arn
   aws_region            = var.aws_region
   dns_ns_name           = var.dns_ns_name
 }
@@ -38,8 +39,6 @@ module "control-api-sidecar" {
   cluster_id            = module.infrastructure.gm_cluster_id
   subnets               = var.private_subnets
   gm_sg_id              = module.infrastructure.gm_sg_id
-  access_key_arn        = var.access_key_arn
-  secret_access_key_arn = var.secret_access_key_arn
   name                  = "control-api"
   control_port          = 50001
   aws_region            = var.aws_region
@@ -55,8 +54,6 @@ module "edge" {
   cluster_id            = module.infrastructure.gm_cluster_id
   subnets               = var.public_subnets
   gm_sg_id              = module.infrastructure.gm_sg_id
-  access_key_arn        = var.access_key_arn
-  secret_access_key_arn = var.secret_access_key_arn
   control_port          = 50001
   aws_region            = var.aws_region
   dns_ns_name           = var.dns_ns_name

--- a/greymatter/main.tf
+++ b/greymatter/main.tf
@@ -40,7 +40,6 @@ module "control-api-sidecar" {
   subnets               = var.private_subnets
   gm_sg_id              = module.infrastructure.gm_sg_id
   name                  = "control-api"
-  control_port          = 50001
   aws_region            = var.aws_region
   dns_ns_name           = var.dns_ns_name
 }
@@ -54,7 +53,6 @@ module "edge" {
   cluster_id            = module.infrastructure.gm_cluster_id
   subnets               = var.public_subnets
   gm_sg_id              = module.infrastructure.gm_sg_id
-  control_port          = 50001
   aws_region            = var.aws_region
   dns_ns_name           = var.dns_ns_name
 }

--- a/greymatter/modules/edge/output.tf
+++ b/greymatter/modules/edge/output.tf
@@ -1,3 +1,4 @@
+# edge lb dns name - for ingress to mesh
 output "edge_dns" {
   value = aws_lb.edge.dns_name
 }

--- a/greymatter/modules/edge/security_groups.tf
+++ b/greymatter/modules/edge/security_groups.tf
@@ -1,5 +1,4 @@
-# security groups
-
+# edge security group
 resource "aws_security_group" "edge-sg" {
   name   = "edge-sg"
   vpc_id = var.vpc_id

--- a/greymatter/modules/edge/services.tf
+++ b/greymatter/modules/edge/services.tf
@@ -1,11 +1,4 @@
-
-
-# service definition
-
-resource "aws_route53_zone" "gm" {
-  name = var.dns_ns_name
-}
-
+# edge ecs service, linked to edge lb
 resource "aws_ecs_service" "edge" {
   name            = "edge"
   cluster         = var.cluster_id
@@ -26,6 +19,12 @@ resource "aws_ecs_service" "edge" {
   depends_on = [aws_lb_target_group.edge]
 }
 
+# public route53 zone creating ingress into mesh
+resource "aws_route53_zone" "gm" {
+  name = var.dns_ns_name
+}
+
+# route53 record for edge for easier ingress
 resource "aws_route53_record" "edge" {
   zone_id = aws_route53_zone.gm.id
   name    = "edge.${var.dns_ns_name}"

--- a/greymatter/modules/edge/tasks.tf
+++ b/greymatter/modules/edge/tasks.tf
@@ -1,6 +1,5 @@
 
-# task definitions
-
+# edge ecs task definition
 resource "aws_ecs_task_definition" "edge-task" {
   family                   = "edge"
   container_definitions    = local.sidecar_container
@@ -12,9 +11,7 @@ resource "aws_ecs_task_definition" "edge-task" {
   task_role_arn            = var.execution_role_arn
 }
 
-# task defs with variables defined here:
-
-
+# edge container definitions
 locals {
   sidecar_container = <<DEFINITION
 [
@@ -49,7 +46,7 @@ locals {
             },
             {
                 "name": "XDS_PORT",
-                "value": "${var.control_port}"
+                "value": "50001"
             },
             {
                 "name": "XDS_ZONE",
@@ -74,5 +71,4 @@ locals {
       }
 ]
     DEFINITION
-
 }

--- a/greymatter/modules/edge/variables.tf
+++ b/greymatter/modules/edge/variables.tf
@@ -1,3 +1,7 @@
+variable "aws_region" {
+  description = "AWS Region"
+}
+
 variable "vpc_id" {
   description = "ID for the VPC of the Grey Matter ECS Cluster"
 }
@@ -9,24 +13,6 @@ variable "cluster_id" {
 variable "subnets" {
   type        = list(string)
   description = "List of private subnet ids in VPC. Sidecar tasks must be launched in private subnets (awsvpc network type)."
-}
-
-variable "sidecar_port" {
-  default     = 10808
-  description = "The port to use for ingress traffic to the sidecar."
-}
-
-variable "aws_region" {
-  description = "AWS Region"
-}
-
-variable "dns_ns_name" {
-  description = "Domain name for the Route 53 Hosted Zone to find and connect to Grey Matter Control"
-}
-
-variable "control_port" {
-  description = "The port on which Grey Matter Control is running."
-  default     = 50001
 }
 
 variable "execution_role_arn" {
@@ -43,4 +29,16 @@ variable "docker_secret_arn" {
 
 variable "gm_sg_id" {
   description = "ID of the security group for ECS Instances"
+}
+
+# optional variables
+
+variable "dns_ns_name" {
+  description = "Desired domain name for the Route 53 Hosted Zone"
+  default     = "greymatter.dev"
+}
+
+variable "sidecar_port" {
+  default     = 10808
+  description = "The port to use for ingress traffic to the sidecar."
 }

--- a/greymatter/modules/edge/variables.tf
+++ b/greymatter/modules/edge/variables.tf
@@ -44,11 +44,3 @@ variable "docker_secret_arn" {
 variable "gm_sg_id" {
   description = "ID of the security group for ECS Instances"
 }
-
-variable "access_key_arn" {
-  description = "ARN of existing Systems Manager Parameter for AWS Access Key (see README)"
-}
-
-variable "secret_access_key_arn" {
-  description = "ARN of existing Systems Manager parameter for AWS Secret Access Key (see README)"
-}

--- a/greymatter/modules/infrastructure/credentials.tf
+++ b/greymatter/modules/infrastructure/credentials.tf
@@ -1,4 +1,15 @@
-# create ssm parameters for access key and secret access key
+# create docker credentials secret for greymatter nexus
+resource "aws_secretsmanager_secret" "docker_gm" {
+  name_prefix = "gm-docker-secret"
+}
+
+resource "aws_secretsmanager_secret_version" "docker_gm" {
+  secret_id     = aws_secretsmanager_secret.docker_gm.id
+  secret_string = jsonencode(var.docker_gm_credentials)
+}
+
+# create ssm paramters with access key and secret access key
+# for Grey Matter control & infrastructure role policies
 resource "aws_ssm_parameter" "aws_access_key" {
   name        = "greymatter-ecs-aws-access-key"
   description = "AWS Access Key ID for Grey Matter Control"
@@ -19,12 +30,4 @@ data "aws_kms_alias" "ssm" {
 
 data "aws_kms_alias" "secretsmanager" {
   name = "alias/aws/secretsmanager"
-}
-
-output "ssm_access_key_arn" {
-  value = aws_ssm_parameter.aws_access_key.arn
-}
-
-output "ssm_secret_access_key_arn" {
-  value = aws_ssm_parameter.aws_secret_access_key.arn
 }

--- a/greymatter/modules/infrastructure/ecs-cluster.tpl
+++ b/greymatter/modules/infrastructure/ecs-cluster.tpl
@@ -1,8 +1,9 @@
 #!/bin/bash
-echo ECS_CLUSTER=${ecs_cluster} >> /etc/ecs/ecs.config
-echo ECS_BACKEND_HOST= >> /etc/ecs/ecs.config
-echo ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true >> /etc/ecs/ecs.config
-echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
-echo ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs"]' >> /etc/ecs/ecs.config
-echo ECS_AWSVPC_BLOCK_IMDS=false >> /etc/ecs/ecs.config
-echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
+export ECS_CONFIG=/etc/ecs/ecs.config
+echo ECS_CLUSTER=${ecs_cluster} >> $ECS_CONFIG
+echo ECS_BACKEND_HOST= >> $ECS_CONFIG
+echo ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true >> $ECS_CONFIG
+echo ECS_ENABLE_TASK_IAM_ROLE=true >> $ECS_CONFIG
+echo ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs"]' >> $ECS_CONFIG
+echo ECS_AWSVPC_BLOCK_IMDS=false >> $ECS_CONFIG
+echo ECS_ENABLE_CONTAINER_METADATA=true >> $ECS_CONFIG

--- a/greymatter/modules/infrastructure/ecs-cluster.tpl
+++ b/greymatter/modules/infrastructure/ecs-cluster.tpl
@@ -1,2 +1,8 @@
 #!/bin/bash
-echo ECS_CLUSTER=${ecs_cluster} >> /etc/ecs/ecs.config;echo ECS_BACKEND_HOST= >> /etc/ecs/ecs.config;echo ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true >> /etc/ecs/ecs.config;echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config;echo ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs"]' >> /etc/ecs/ecs.config;echo ECS_AWSVPC_BLOCK_IMDS=false >> /etc/ecs/ecs.config;echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
+echo ECS_CLUSTER=${ecs_cluster} >> /etc/ecs/ecs.config
+echo ECS_BACKEND_HOST= >> /etc/ecs/ecs.config
+echo ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true >> /etc/ecs/ecs.config
+echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
+echo ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs"]' >> /etc/ecs/ecs.config
+echo ECS_AWSVPC_BLOCK_IMDS=false >> /etc/ecs/ecs.config
+echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config

--- a/greymatter/modules/infrastructure/ecs-roles.tf
+++ b/greymatter/modules/infrastructure/ecs-roles.tf
@@ -41,9 +41,9 @@ data "aws_iam_policy_document" "ssm_policy" {
       "kms:Decrypt",
     ]
     resources = [
-      "${var.access_key_arn}",
-      "${var.secret_access_key_arn}",
-      "${var.kms_ssm_arn}"
+      "${aws_ssm_parameter.aws_access_key.arn}",
+      "${aws_ssm_parameter.aws_secret_access_key.arn}",
+      "${data.aws_kms_alias.ssm.arn}"
     ]
   }
 }
@@ -98,7 +98,7 @@ data "aws_iam_policy_document" "docker_policy" {
     ]
     resources = [
       "${aws_secretsmanager_secret.docker_gm.arn}",
-      "${var.kms_secretsmanager_arn}"
+      "${data.aws_kms_alias.secretsmanager.arn}"
     ]
   }
 }

--- a/greymatter/modules/infrastructure/ecs-roles.tf
+++ b/greymatter/modules/infrastructure/ecs-roles.tf
@@ -1,4 +1,4 @@
-# ECS Service Role
+# ECS Service Role - will be used by all ecs services
 resource "aws_iam_role" "ecs-service-role" {
   name               = "gm-ecs-service-role"
   path               = "/"
@@ -16,7 +16,6 @@ data "aws_iam_policy_document" "ecs-service-assume-policy" {
   }
 }
 
-# attach managed
 resource "aws_iam_role_policy_attachment" "ecs-service-role-managed-attachment" {
   role       = aws_iam_role.ecs-service-role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
@@ -28,7 +27,6 @@ resource "aws_iam_policy" "ecs-policy-ssm" {
   policy      = data.aws_iam_policy_document.ssm_policy.json
 }
 
-# attach ssm
 resource "aws_iam_role_policy_attachment" "ecs-service-role-ssm-attachment" {
   role       = aws_iam_role.ecs-service-role.name
   policy_arn = aws_iam_policy.ecs-policy-ssm.arn
@@ -48,7 +46,7 @@ data "aws_iam_policy_document" "ssm_policy" {
   }
 }
 
-# ECS Task Execution Role
+# ECS Task Execution Role - will be used by all ecs tasks
 resource "aws_iam_role" "ecs-task-execution-role" {
   name               = "gm-ecs-task-execution-role"
   path               = "/"
@@ -66,19 +64,16 @@ data "aws_iam_policy_document" "ecs-task-execution-role-assume-policy" {
   }
 }
 
-# attach managed
 resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-managed-attachment" {
   role       = aws_iam_role.ecs-task-execution-role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-# attach ssm policy
 resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-ssm-policy-attachment" {
   role       = aws_iam_role.ecs-task-execution-role.name
   policy_arn = aws_iam_policy.ecs-policy-ssm.arn
 }
 
-# attach secretsmanager policy
 resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-secrets-policy-attachment" {
   role       = aws_iam_role.ecs-task-execution-role.name
   policy_arn = aws_iam_policy.ecs-policy-secretsmanager.arn
@@ -103,17 +98,35 @@ data "aws_iam_policy_document" "docker_policy" {
   }
 }
 
-# AutoScaling Service Role
+# AutoScaling Service Role - used for infrastructure autoscaling group
 resource "aws_iam_service_linked_role" "service-role-for-autoscaling" {
   aws_service_name = "autoscaling.amazonaws.com"
   custom_suffix    = "gm-ecs"
 }
 
-# outputs
-output "ecs-service-role-arn" {
-  value = aws_iam_role.ecs-service-role.arn
+# Ecs Agent IAM role - used for infrastructure launch config
+data "aws_iam_policy_document" "ecs_agent" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com", "ecs.amazonaws.com"]
+    }
+  }
 }
 
-output "ecs-task-execution-role-arn" {
-  value = aws_iam_role.ecs-task-execution-role.arn
+resource "aws_iam_role" "ecs_agent" {
+  name               = "ecs-agent"
+  assume_role_policy = data.aws_iam_policy_document.ecs_agent.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_agent" {
+  role       = aws_iam_role.ecs_agent.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_agent" {
+  name = "ecs-agent"
+  role = aws_iam_role.ecs_agent.name
 }

--- a/greymatter/modules/infrastructure/infrastructure.tf
+++ b/greymatter/modules/infrastructure/infrastructure.tf
@@ -139,7 +139,6 @@ resource "aws_secretsmanager_secret_version" "docker_gm" {
   secret_string = jsonencode(var.docker_gm_credentials)
 }
 
-
 # outputs
 output "gm_sg_id" {
   value = aws_security_group.gm-sg.id

--- a/greymatter/modules/infrastructure/infrastructure.tf
+++ b/greymatter/modules/infrastructure/infrastructure.tf
@@ -1,5 +1,4 @@
 # cluster security group
-
 resource "aws_security_group" "gm-sg" {
   name   = "gm-sg"
   vpc_id = var.vpc_id
@@ -19,8 +18,7 @@ resource "aws_security_group" "gm-sg" {
   }
 }
 
-# autoscaling group
-
+# ecs cluster
 resource "aws_ecs_cluster" "gm-cluster" {
   name       = var.cluster_name
   depends_on = [aws_autoscaling_group.ecs-autoscaling-group]
@@ -34,27 +32,7 @@ data "template_file" "ecs-cluster" {
   }
 }
 
-data "aws_ami" "ecs" {
-  most_recent = true # get the latest version
-
-  filter {
-    name = "name"
-    values = [
-    "amzn2-ami-ecs-hvm-2*"] # ECS optimized image
-  }
-
-  filter {
-    name = "virtualization-type"
-    values = [
-    "hvm"]
-  }
-
-  owners = [
-    "amazon" # Only official images
-  ]
-}
-
-# TODO add size, instances variables
+# launch config for ecs cluster
 resource "aws_launch_configuration" "ecs-launch-configuration" {
   name                 = "ecs-launch-configuration"
   image_id             = var.optimized_ami
@@ -76,34 +54,7 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
   user_data                   = data.template_file.ecs-cluster.rendered
 }
 
-
-data "aws_iam_policy_document" "ecs_agent" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["ec2.amazonaws.com", "ecs.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "ecs_agent" {
-  name               = "ecs-agent"
-  assume_role_policy = data.aws_iam_policy_document.ecs_agent.json
-}
-
-
-resource "aws_iam_role_policy_attachment" "ecs_agent" {
-  role       = aws_iam_role.ecs_agent.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
-}
-
-resource "aws_iam_instance_profile" "ecs_agent" {
-  name = "ecs-agent"
-  role = aws_iam_role.ecs_agent.name
-}
-
+# autoscaling group for ecs cluster launch config
 resource "aws_autoscaling_group" "ecs-autoscaling-group" {
   name                 = "ecs-autoscaling-group"
   max_size             = var.max_instances
@@ -116,8 +67,6 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
     {
       key   = "Name"
       value = var.cluster_name,
-
-      # Make sure EC2 instances are tagged with this tag as well
       propagate_at_launch = true
     }
   ]
@@ -125,29 +74,7 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
   depends_on              = [aws_iam_service_linked_role.service-role-for-autoscaling]
 }
 
+# cloudwatch group for ecs task logs
 resource "aws_cloudwatch_log_group" "greymatter-logs" {
   name = "greymatter"
-}
-
-# create docker credentials secret (replaces docker_secret_arn var)
-resource "aws_secretsmanager_secret" "docker_gm" {
-  name_prefix = "gm-docker-secret"
-}
-
-resource "aws_secretsmanager_secret_version" "docker_gm" {
-  secret_id     = aws_secretsmanager_secret.docker_gm.id
-  secret_string = jsonencode(var.docker_gm_credentials)
-}
-
-# outputs
-output "gm_sg_id" {
-  value = aws_security_group.gm-sg.id
-}
-
-output "gm_cluster_id" {
-  value = aws_ecs_cluster.gm-cluster.id
-}
-
-output "docker_secret_arn" {
-  value = aws_secretsmanager_secret.docker_gm.arn
 }

--- a/greymatter/modules/infrastructure/output.tf
+++ b/greymatter/modules/infrastructure/output.tf
@@ -1,0 +1,35 @@
+# outputs - needed for other modules
+
+# output info on gm security group and the gm ecs cluster created
+# found in infrastructure.tf
+output "gm_sg_id" {
+  value = aws_security_group.gm-sg.id
+}
+
+output "gm_cluster_id" {
+  value = aws_ecs_cluster.gm-cluster.id
+}
+
+# output info on credentials resources
+# found in credentials.tf
+output "docker_secret_arn" {
+  value = aws_secretsmanager_secret.docker_gm.arn
+}
+
+output "ssm_access_key_arn" {
+  value = aws_ssm_parameter.aws_access_key.arn
+}
+
+output "ssm_secret_access_key_arn" {
+  value = aws_ssm_parameter.aws_secret_access_key.arn
+}
+
+# output info on aws iam roles needed for ecs services/tasks
+# found in ecs-roles.tf
+output "ecs-service-role-arn" {
+  value = aws_iam_role.ecs-service-role.arn
+}
+
+output "ecs-task-execution-role-arn" {
+  value = aws_iam_role.ecs-task-execution-role.arn
+}

--- a/greymatter/modules/infrastructure/ssm.tf
+++ b/greymatter/modules/infrastructure/ssm.tf
@@ -1,0 +1,30 @@
+# create ssm parameters for access key and secret access key
+resource "aws_ssm_parameter" "aws_access_key" {
+  name        = "greymatter-ecs-aws-access-key"
+  description = "AWS Access Key ID for Grey Matter Control"
+  type        = "SecureString"
+  value       = var.aws_access_key_id
+}
+
+resource "aws_ssm_parameter" "aws_secret_access_key" {
+  name        = "greymatter-ecs-aws-secret-access-key"
+  description = "AWS Secret Access Key ID for Grey Matter Control"
+  type        = "SecureString"
+  value       = var.aws_secret_access_key
+}
+
+data "aws_kms_alias" "ssm" {
+  name = "alias/aws/ssm"
+}
+
+data "aws_kms_alias" "secretsmanager" {
+  name = "alias/aws/secretsmanager"
+}
+
+output "ssm_access_key_arn" {
+  value = aws_ssm_parameter.aws_access_key.arn
+}
+
+output "ssm_secret_access_key_arn" {
+  value = aws_ssm_parameter.aws_secret_access_key.arn
+}

--- a/greymatter/modules/infrastructure/test.txt
+++ b/greymatter/modules/infrastructure/test.txt
@@ -1,1 +1,0 @@
-hello world!

--- a/greymatter/modules/infrastructure/variables.tf
+++ b/greymatter/modules/infrastructure/variables.tf
@@ -29,22 +29,6 @@ variable "min_instances" {
   default = 0
 }
 
-variable "access_key_arn" {
-  description = "ARN of existing Systems Manager Parameter for AWS Access Key (see README)"
-}
-
-variable "secret_access_key_arn" {
-  description = "ARN of existing Systems Manager parameter for AWS Secret Access Key (see README)"
-}
-
-variable "kms_ssm_arn" {
-  description = "ARN of Key Management Service AWS managed key with alias aws/ssm. Find it here: `aws kms describe-key --key-id alias/aws/ssm`."
-}
-
-variable "kms_secretsmanager_arn" {
-  description = "ARN of Key Management Service AWS managed key with alias aws/secretsmanager. Find it here: `aws kms describe-key --key-id alias/aws/secretsmanager`."
-}
-
 variable "optimized_ami" {
   description = "ECS Optimized AMI for region - found here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html"
 }
@@ -56,4 +40,12 @@ variable "docker_gm_credentials" {
   }
   description = "Docker credentials for greymatter nexus repository"
   type        = map(string)
+}
+
+variable "aws_access_key_id" {
+  description = "AWS Secret Access Key"
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS Secret Access Key"
 }

--- a/greymatter/modules/infrastructure/variables.tf
+++ b/greymatter/modules/infrastructure/variables.tf
@@ -2,11 +2,6 @@ variable "vpc_id" {
   description = "ID for the VPC to launch Grey Matter ECS Cluster"
 }
 
-variable "cluster_name" {
-  default     = "gm-cluster"
-  description = "Name of the Grey Matter ECS Cluster"
-}
-
 variable "key_pair_name" {
   description = "Existing AWS Key Pair for EC2 Instances"
 }
@@ -14,6 +9,30 @@ variable "key_pair_name" {
 variable "subnets" {
   type        = list(string)
   description = "List of all subnets, private and public, in the VPC"
+}
+
+variable "optimized_ami" {
+  description = "ECS Optimized AMI for region - found here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html"
+}
+
+variable "docker_gm_credentials" {
+  description = "Docker credentials for greymatter nexus repository"
+  type        = map(string)
+}
+
+variable "aws_access_key_id" {
+  description = "AWS Secret Access Key"
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS Secret Access Key"
+}
+
+# optional vars
+
+variable "cluster_name" {
+  default     = "gm-cluster"
+  description = "Name of the Grey Matter ECS Cluster"
 }
 
 variable "instance_type" {
@@ -27,25 +46,4 @@ variable "max_instances" {
 
 variable "min_instances" {
   default = 0
-}
-
-variable "optimized_ami" {
-  description = "ECS Optimized AMI for region - found here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html"
-}
-
-variable "docker_gm_credentials" {
-  default = {
-    key1 = "username"
-    key2 = "password"
-  }
-  description = "Docker credentials for greymatter nexus repository"
-  type        = map(string)
-}
-
-variable "aws_access_key_id" {
-  description = "AWS Secret Access Key"
-}
-
-variable "aws_secret_access_key" {
-  description = "AWS Secret Access Key"
 }

--- a/greymatter/modules/sidecar/security_groups.tf
+++ b/greymatter/modules/sidecar/security_groups.tf
@@ -1,5 +1,4 @@
-# security groups
-
+# sidecar security group
 resource "aws_security_group" "sidecar-sg" {
   name   = "${var.name}-sidecar-sg"
   vpc_id = var.vpc_id

--- a/greymatter/modules/sidecar/services.tf
+++ b/greymatter/modules/sidecar/services.tf
@@ -1,7 +1,6 @@
 
 
-# service definition
-
+# sidecar ecs service
 resource "aws_ecs_service" "sidecar" {
   name            = "${var.name}-sidecar"
   cluster         = var.cluster_id

--- a/greymatter/modules/sidecar/tasks.tf
+++ b/greymatter/modules/sidecar/tasks.tf
@@ -1,6 +1,5 @@
 
-# task definitions
-
+# sidecar task definition
 resource "aws_ecs_task_definition" "sidecar-task" {
   family                   = "${var.name}-sidecar"
   container_definitions    = local.sidecar_container
@@ -12,9 +11,7 @@ resource "aws_ecs_task_definition" "sidecar-task" {
   task_role_arn            = var.execution_role_arn
 }
 
-# task defs with variables defined here:
-
-
+# sidecar container definition
 locals {
   sidecar_container = <<DEFINITION
 [
@@ -49,7 +46,7 @@ locals {
             },
             {
                 "name": "XDS_PORT",
-                "value": "${var.control_port}"
+                "value": "50001"
             },
             {
                 "name": "XDS_ZONE",
@@ -74,5 +71,4 @@ locals {
       }
 ]
     DEFINITION
-
 }

--- a/greymatter/modules/sidecar/variables.tf
+++ b/greymatter/modules/sidecar/variables.tf
@@ -1,3 +1,8 @@
+
+variable "aws_region" {
+  description = "AWS Region"
+}
+
 variable "vpc_id" {
   description = "ID for the VPC of the Grey Matter ECS Cluster"
 }
@@ -15,24 +20,6 @@ variable "name" {
   description = "Unique name for the sidecar - this is what will be used for discovery"
 }
 
-variable "sidecar_port" {
-  default     = 10808
-  description = "The port to use for ingress traffic to the sidecar."
-}
-
-variable "aws_region" {
-  description = "AWS Region"
-}
-
-variable "dns_ns_name" {
-  description = "Domain name for the Route 53 Hosted Zone to find and connect to Grey Matter Control"
-}
-
-variable "control_port" {
-  description = "The port on which Grey Matter Control is running."
-  default     = 50001
-}
-
 variable "execution_role_arn" {
   description = "ECS Task Execution Role ARN generated in the infrastructure module."
 }
@@ -47,4 +34,16 @@ variable "docker_secret_arn" {
 
 variable "gm_sg_id" {
   description = "ID of the security group for ECS Instances"
+}
+
+# optional vars
+
+variable "dns_ns_name" {
+  description = "Domain name of the route53 zone to reach Grey Matter fabric (will be prefixed with 'fabric.')"
+  default     = "greymatter.dev"
+}
+
+variable "sidecar_port" {
+  default     = 10808
+  description = "The port to use for ingress traffic to the sidecar."
 }

--- a/greymatter/modules/sidecar/variables.tf
+++ b/greymatter/modules/sidecar/variables.tf
@@ -48,11 +48,3 @@ variable "docker_secret_arn" {
 variable "gm_sg_id" {
   description = "ID of the security group for ECS Instances"
 }
-
-variable "access_key_arn" {
-  description = "ARN of existing Systems Manager Parameter for AWS Access Key (see README)"
-}
-
-variable "secret_access_key_arn" {
-  description = "ARN of existing Systems Manager parameter for AWS Secret Access Key (see README)"
-}

--- a/greymatter/variables.tf
+++ b/greymatter/variables.tf
@@ -3,11 +3,6 @@ variable "vpc_id" {
   description = "ID for the VPC to launch Grey Matter ECS Cluster"
 }
 
-variable "cluster_name" {
-  default     = "gm-cluster"
-  description = "Name of the Grey Matter ECS Cluster"
-}
-
 variable "key_pair_name" {
   description = "Existing AWS Key Pair for EC2 Instances"
 }
@@ -22,28 +17,8 @@ variable "private_subnets" {
   description = "List of private subnet ids in VPC"
 }
 
-variable "access_key_arn" {
-  description = "ARN of existing Systems Manager Parameter for AWS Access Key (see README)"
-}
-
-variable "secret_access_key_arn" {
-  description = "ARN of existing Systems Manager parameter for AWS Secret Access Key (see README)"
-}
-
 variable "aws_region" {
   description = "AWS Region"
-}
-
-variable "dns_ns_name" {
-  description = "Desired domain name for new Route 53 Hosted Zone"
-}
-
-variable "kms_ssm_arn" {
-  description = "ARN of Key Management Service AWS managed key with alias aws/ssm. Find it here: `aws kms describe-key --key-id alias/aws/ssm`."
-}
-
-variable "kms_secretsmanager_arn" {
-  description = "ARN of Key Management Service AWS managed key with alias aws/secretsmanager. Find it here: `aws kms describe-key --key-id alias/aws/secretsmanager`."
 }
 
 variable "optimized_ami" {
@@ -51,10 +26,39 @@ variable "optimized_ami" {
 }
 
 variable "docker_gm_credentials" {
-  default = {
-    key1 = "username"
-    key2 = "password"
-  }
   description = "Docker credentials for greymatter nexus repository"
   type        = map(string)
+}
+
+variable "aws_access_key_id" {
+  description = "AWS Secret Access Key"
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS Secret Access Key"
+}
+
+# optional vars
+
+variable "cluster_name" {
+  default     = "gm-cluster"
+  description = "Name of the Grey Matter ECS Cluster"
+}
+
+variable "dns_ns_name" {
+  description = "Desired domain name for new Route 53 Hosted Zone"
+  default     = "greymatter.dev"
+}
+
+variable "ec2_instance_type" {
+  default     = "t3.xlarge"
+  description = "Instance type for EC2 instances."
+}
+
+variable "ec2_max_instances" {
+  default = 3
+}
+
+variable "ec2_min_instances" {
+  default = 0
 }

--- a/main.tf
+++ b/main.tf
@@ -88,14 +88,15 @@ module "greymatter" {
   vpc_id                 = aws_vpc.vpc.id
   public_subnets         = [aws_subnet.public.0.id, aws_subnet.public.1.id]
   private_subnets        = [aws_subnet.private.0.id, aws_subnet.private.1.id]
-  access_key_arn         = var.access_key_arn
-  secret_access_key_arn  = var.secret_access_key_arn
   aws_region             = var.aws_region
   dns_ns_name            = var.dns_ns_name
-  kms_ssm_arn            = var.kms_ssm_arn
-  kms_secretsmanager_arn = var.kms_secretsmanager_arn
   optimized_ami          = var.optimized_ami
   docker_gm_credentials  = var.docker_gm_credentials
+  aws_access_key_id      = var.aws_access_key_id
+  aws_secret_access_key  = var.aws_secret_access_key
+  ec2_instance_type      = var.ec2_instance_type
+  ec2_max_instances      = var.ec2_max_instances
+  ec2_min_instances      = var.ec2_min_instances
 }
 
 output "edge_dns" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,35 +1,9 @@
-variable "cluster_name" {
-  default     = "gm-cluster"
-  description = "Name of the Grey Matter ECS Cluster"
-}
-
-variable "key_pair_name" {
-  description = "Existing AWS Key Pair for EC2 Instances"
-}
-
-variable "access_key_arn" {
-  description = "ARN of existing Systems Manager Parameter for AWS Access Key (see README)"
-}
-
-variable "secret_access_key_arn" {
-  description = "ARN of existing Systems Manager parameter for AWS Secret Access Key (see README)"
-}
-
 variable "aws_region" {
   description = "AWS Region"
 }
 
-variable "dns_ns_name" {
-  description = "Desired domain name for new Route 53 Hosted Zone"
-  default     = "greymatter.dev"
-}
-
-variable "kms_ssm_arn" {
-  description = "ARN of Key Management Service AWS managed key with alias aws/ssm. Find it here: `aws kms describe-key --key-id alias/aws/ssm`."
-}
-
-variable "kms_secretsmanager_arn" {
-  description = "ARN of Key Management Service AWS managed key with alias aws/secretsmanager. Find it here: `aws kms describe-key --key-id alias/aws/secretsmanager`."
+variable "key_pair_name" {
+  description = "Existing AWS Key Pair for EC2 Instances"
 }
 
 variable "optimized_ami" {
@@ -37,10 +11,39 @@ variable "optimized_ami" {
 }
 
 variable "docker_gm_credentials" {
-  default = {
-    key1 = "username"
-    key2 = "password"
-  }
   description = "Docker credentials for greymatter nexus repository"
   type        = map(string)
+}
+
+variable "aws_access_key_id" {
+  description = "AWS Secret Access Key"
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS Secret Access Key"
+}
+
+# optional vars
+
+variable "cluster_name" {
+  default     = "gm-cluster"
+  description = "Name of the Grey Matter ECS Cluster"
+}
+
+variable "dns_ns_name" {
+  description = "Desired domain name for new Route 53 Hosted Zone"
+  default     = "greymatter.dev"
+}
+
+variable "ec2_instance_type" {
+  default     = "t3.xlarge"
+  description = "Instance type for EC2 instances."
+}
+
+variable "ec2_max_instances" {
+  default = 3
+}
+
+variable "ec2_min_instances" {
+  default = 0
 }


### PR DESCRIPTION
This PR cleans up a lot of smaller issues, including an attempt at improving clarity within the modules.

closes #11 
closes #20 
closes #24 
closes #28 

To test new env var setup - either check out the new docs [here](https://github.com/greymatter-io/terraform-greymatter-ecs/blob/cleanup/docs/install.md) or

Test with buttermilk sky:

check out `ecs_module_test` in bs, make sure you've awsumed bs-resources-admin, fill in values for `docker_gm_credentials`, `aws_access_key_id` and `aws_secret_access_key` and run `terraform apply`. The biggest change this PR makes it that you no longer need to do steps 1-3 of the [preinstall](https://github.com/greymatter-io/terraform-greymatter-ecs#pre-install).

This also adds coleman to the codeowners so in the future we won't need sofia to review everything :).